### PR TITLE
fix for parsing api responses and generic execute api

### DIFF
--- a/eventsocket.py
+++ b/eventsocket.py
@@ -56,7 +56,7 @@ class EventSocket(basic.LineReceiver):
         self.__crlf = re.compile(r"[\r\n]+")
         self.__rawresponse = [
             "api/response",
-            #"text/disconnect-notice",
+            "text/disconnect-notice",
         ]
 
     def send(self, cmd):
@@ -147,7 +147,7 @@ class EventSocket(basic.LineReceiver):
                 self.dispatchEvent(self.__ctx, self.readRawResponse())
             else:
                 self.dispatchEvent(self.__ctx, self.parseEvent())
-                self.setLineMode(rest)
+            self.setLineMode(rest)
 
 class EventProtocol(EventSocket):
     def __init__(self):


### PR DESCRIPTION
Hi,  

you may want to check out this two modifications.

the first is maybe a typo where self.setLineMode(rest) is not called in rawDataReceived always.
This leads to non being able to send more that one api call (and fixes ligering output too).

the second is a generic execute api.

hope can be useful.
