### PR TITLE
Fix missing linefeed in sendevent when there is no body for the event.

### DIFF
--- a/eventsocket.py
+++ b/eventsocket.py
@@ -252,6 +252,8 @@ class EventProtocol(EventSocket):
         parsed_args.append('')
         if body:
             parsed_args.append(body)
+        else:
+            parsed_args.append('')
         return self.__protocolSendRaw("sendevent", '\n'.join(parsed_args))
 
     def bgapi(self, args):


### PR DESCRIPTION
When no body is specified, an extra LF needs to be sent.
