### PR TITLE
Comparability with twisted 15.2

### DIFF
--- a/eventsocket.py
+++ b/eventsocket.py
@@ -26,7 +26,7 @@ from twisted.internet import defer, reactor, protocol
 
 log = Logger()
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 class EventError(Exception):
     pass

--- a/eventsocket.py
+++ b/eventsocket.py
@@ -20,9 +20,11 @@ import types
 import string
 import re, urllib
 from cStringIO import StringIO
-from twisted.python import log
+from twisted.logger import Logger
 from twisted.protocols import basic
 from twisted.internet import defer, reactor, protocol
+
+log = Logger()
 
 __version__ = "0.1.4"
 
@@ -232,12 +234,10 @@ class EventProtocol(EventSocket):
             return self.unboundEvent(ctx.data, evname)
 
     def unknownContentType(self, content_type, ctx):
-        log.err("[eventsocket] unknown Content-Type: %s" % content_type,
-            logLevel=log.logging.DEBUG)
+        log.debug("[eventsocket] unknown Content-Type: %s" % content_type)
 
     def unboundEvent(self, ctx, evname):
-        log.err("[eventsocket] unbound Event: %s" % evname,
-            logLevel=log.logging.DEBUG)
+        log.debug("[eventsocket] unbound Event: %s" % evname)
 
     # EVENT SOCKET COMMANDS
     def api(self, args):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="eventsocket",
-    version="0.1.4",
+    version="0.1.5",
     description="Twisted protocol for the FreeSWITCH's Event Socket",
     author="Alexandre Fiori",
     url="http://github.com/fiorix/eventsocket",

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(
     author="Alexandre Fiori",
     url="http://github.com/fiorix/eventsocket",
     py_modules=["eventsocket"],
-    install_requires=["twisted"],
+    install_requires=["twisted>=15.2"],
 )


### PR DESCRIPTION
Twisted 15.2 added a bunch of changes to logging stuff, which broke the logging from this module. This fixes those problems and pins to the first version of twisted with the changes. Also bumps the version.
